### PR TITLE
Create strongly-typed Operator factory versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ var queryCaml =
         .OrderBy(new FieldReference("Age") { Ascending = false })
         .GroupBy("Address")
         .GetCaml();
+
+// or the strongly-typed equivalent
+
+var and =
+    LogicalJoin.And(
+        Operator.Contains<MyClass, string>(m => m.HairColors, ValueType.Text, "brown"),
+        Operator.BeginsWith<MyClass, string>(m => m.Name, ValueType.Text, "John"),
+        Operator.GreaterThanOrEqualTo<MyClass, int>(m => m.Age, ValueType.Integer, 21),
+        LogicalJoin.Or(
+            Operator.IsNotNull<MyClass, double>(m => m.Counter),
+            Operator.IsNull<MyClass, bool>(m => m.Flag)));
+
+var queryCaml =
+    Query.Build(and)
+        .OrderBy<MyClass, string>(m => m.Country)
+        .OrderBy(new FieldReference<MyClass, int>(m => m.Age) { Ascending = false })
+        .GroupBy<MyClass, string>(m => m.Address)
+        .GetCaml();
+
 ```
 
 ## Output:

--- a/src/CamlBuilder/Internal/Operators/MembershipOperator.cs
+++ b/src/CamlBuilder/Internal/Operators/MembershipOperator.cs
@@ -4,17 +4,17 @@ namespace CamlBuilder.Internal.Operators
 
     internal class MembershipOperator : Operator
     {
-        private readonly MembershipType membershipType;
+        private readonly MembershipType _membershipType;
 
         public MembershipOperator(FieldReference fieldRef, MembershipType membershipType)
             : base(OperatorType.Membership, fieldRef)
         {
-            this.membershipType = membershipType;
+            this._membershipType = membershipType;
         }
 
         private string GetMembershipTypeString()
         {
-            switch (membershipType)
+            switch (_membershipType)
             {
                 case MembershipType.SpWebAllUsers:
                     return "SPWeb.AllUsers";

--- a/src/CamlBuilder/Internal/Values/AnyValue.cs
+++ b/src/CamlBuilder/Internal/Values/AnyValue.cs
@@ -2,17 +2,17 @@ namespace CamlBuilder.Internal.Values
 {
     internal class AnyValue : Value
     {
-        private readonly object anyValue;
+        private readonly object _anyValue;
 
         public AnyValue(ValueType type, bool? includeTimeValue, object anyValue)
             : base(type, includeTimeValue)
         {
-            this.anyValue = anyValue;
+            this._anyValue = anyValue;
         }
 
         protected override string GetCamlValue()
         {
-            return anyValue.ToString();
+            return _anyValue.ToString();
         }
     }
 }

--- a/src/CamlBuilder/Internal/Values/ListPropertyValue.cs
+++ b/src/CamlBuilder/Internal/Values/ListPropertyValue.cs
@@ -5,7 +5,7 @@
 
     internal class ListPropertyValue : Value
     {
-        private readonly ListPropertyValueItem[] items;
+        private readonly ListPropertyValueItem[] _items;
 
         public ListPropertyValue(
             ValueType type, 
@@ -13,12 +13,12 @@
             IEnumerable<ListPropertyValueItem> items)
             : base(type, includeTimeValue)
         {
-            this.items = items.ToArray();
+            this._items = items.ToArray();
         }
 
         protected override string GetCamlValue()
         {
-            return string.Join("\n", items.Select(GetItemElement));
+            return string.Join("\n", _items.Select(GetItemElement));
         }
 
         private string GetItemElement(ListPropertyValueItem item)

--- a/src/CamlBuilder/Internal/Values/TodayValue.cs
+++ b/src/CamlBuilder/Internal/Values/TodayValue.cs
@@ -2,12 +2,12 @@ namespace CamlBuilder.Internal.Values
 {
     internal class TodayValue : Value
     {
-        private readonly int? offset;
+        private readonly int? _offset;
 
         public TodayValue(bool? includeTimeValue, int? offset)
             : base(ValueType.DateTime, includeTimeValue)
         {
-            this.offset = offset;
+            this._offset = offset;
         }
 
         public TodayValue(bool? includeTimeValue)
@@ -17,8 +17,8 @@ namespace CamlBuilder.Internal.Values
 
         protected override string GetCamlValue()
         {
-            return offset.HasValue
-                ? $"<Today OffsetDays='{offset.Value}'/>"
+            return _offset.HasValue
+                ? $"<Today OffsetDays='{_offset.Value}'/>"
                 : "<Today/>";
         }
     }

--- a/src/CamlBuilder/LogicalJoin.cs
+++ b/src/CamlBuilder/LogicalJoin.cs
@@ -14,15 +14,15 @@
         /// </summary>
         public LogicalJoinType LogicalJoinType { get; }
 
-        private readonly List<Statement> internalStatements;
+        private readonly List<Statement> _internalStatements;
 
-        private readonly string logicalJoinTypeString;
+        private readonly string _logicalJoinTypeString;
 
         private LogicalJoin(LogicalJoinType logicalJoinType, IEnumerable<Statement> statements)
         {
             LogicalJoinType = logicalJoinType;
-            logicalJoinTypeString = logicalJoinType.ToString();
-            internalStatements = statements.ToList();
+            _logicalJoinTypeString = logicalJoinType.ToString();
+            _internalStatements = statements.ToList();
         }
 
         /// <summary>
@@ -31,7 +31,7 @@
         /// <param name="statement">Statement to be added.</param>
         public void AddStatement(Statement statement)
         {
-            internalStatements.Add(statement);
+            _internalStatements.Add(statement);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@
         /// <param name="statements">Statements to be added to logical join.</param>
         public void AddStatements(IEnumerable<Statement> statements)
         {
-            internalStatements.AddRange(statements);
+            _internalStatements.AddRange(statements);
         }
 
         /// <summary>
@@ -50,17 +50,17 @@
         /// <returns>CAML string.</returns>
         public override string GetCaml()
         {
-            if (internalStatements.Count == 0)
+            if (_internalStatements.Count == 0)
             {
                 return string.Empty;
             }
 
-            if (internalStatements.Count == 1)
+            if (_internalStatements.Count == 1)
             {
-                return internalStatements[0].GetCaml();
+                return _internalStatements[0].GetCaml();
             }
 
-            var queue = new Queue<Statement>(internalStatements);
+            var queue = new Queue<Statement>(_internalStatements);
 
             return BuildCamlRecursively(queue);
         }
@@ -70,18 +70,18 @@
             if (statementsQueue.Count == 2)
             {
                 return $@"
-<{logicalJoinTypeString}>
+<{_logicalJoinTypeString}>
     {statementsQueue.Dequeue().GetCaml()}
     {statementsQueue.Dequeue().GetCaml()}
-</{logicalJoinTypeString}>
+</{_logicalJoinTypeString}>
 ";
             }
 
             return $@"
-<{logicalJoinTypeString}>
+<{_logicalJoinTypeString}>
     {statementsQueue.Dequeue().GetCaml()}
     {BuildCamlRecursively(statementsQueue)}
-</{logicalJoinTypeString}>
+</{_logicalJoinTypeString}>
 ";
         }
 

--- a/src/CamlBuilder/Operator.cs
+++ b/src/CamlBuilder/Operator.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq.Expressions;
     using Internal.Operators;
 
     /// <summary>
@@ -64,6 +65,18 @@
             }
         }
 
+        private static string GetPropertyFieldNameOrThrow<T, TProperty>(Expression<Func<T, TProperty>> expression)
+        {
+            var body = expression.Body;
+
+            if (body.NodeType == ExpressionType.MemberAccess)
+            {
+                return ((MemberExpression) body).Member.Name;
+            }
+
+            throw new InvalidOperationException();           
+        }
+
         /// <summary>
         /// Instanciates a new <i>IsNull</i> operator to perform on specified <paramref name="fieldRef"/>.
         /// </summary>
@@ -75,6 +88,18 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>IsNull</i> operator to perform on specified <paramref name="fieldRefProperty"/>.
+        /// </summary>
+        /// <param name="fieldRefProperty">
+        /// Reference to the field to operate on. Name inferred from the specified field/property name.
+        /// </param>
+        /// <returns>IsNull operator instance.</returns>
+        public static Operator IsNull<T, TProperty>(Expression<Func<T, TProperty>> fieldRefProperty)
+        {
+            return new SimpleOperator(OperatorType.IsNull, GetPropertyFieldNameOrThrow(fieldRefProperty));
+        }
+        
+        /// <summary>
         /// Instanciates a new <i>IsNotNull</i> operator to perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -82,6 +107,18 @@
         public static Operator IsNotNull(FieldReference fieldRef)
         {
             return new SimpleOperator(OperatorType.IsNotNull, fieldRef);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>IsNotNull</i> operator to perform on specified <paramref name="fieldRefProperty"/>.
+        /// </summary>
+        /// <param name="fieldRefProperty">
+        /// Reference to the field to operate on. Name inferred from the specified field/property name.
+        /// </param>
+        /// <returns>IsNotNull operator instance.</returns>
+        public static Operator IsNotNull<T, TProperty>(Expression<Func<T, TProperty>> fieldRefProperty)
+        {
+            return new SimpleOperator(OperatorType.IsNotNull, GetPropertyFieldNameOrThrow(fieldRefProperty));
         }
 
         /// <summary>

--- a/src/CamlBuilder/Operator.cs
+++ b/src/CamlBuilder/Operator.cs
@@ -1,10 +1,10 @@
-﻿namespace CamlBuilder
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq.Expressions;
-    using Internal.Operators;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using CamlBuilder.Internal.Operators;
 
+namespace CamlBuilder
+{
     /// <summary>
     /// Defines a CAML operator. This is an abstract class. To instanciate an operator use public static methods.
     /// </summary>
@@ -20,7 +20,7 @@
         /// <summary>
         /// Gets the name of the field on which this operator acts on.
         /// </summary>
-        public FieldReference FieldReference { get; private set; }
+        public FieldReference FieldReference { get; }
 
         protected internal Operator(
             OperatorType operatorType, 
@@ -65,18 +65,6 @@
             }
         }
 
-        private static string GetPropertyFieldNameOrThrow<T, TProperty>(Expression<Func<T, TProperty>> expression)
-        {
-            var body = expression.Body;
-
-            if (body.NodeType == ExpressionType.MemberAccess)
-            {
-                return ((MemberExpression) body).Member.Name;
-            }
-
-            throw new InvalidOperationException();           
-        }
-
         /// <summary>
         /// Instanciates a new <i>IsNull</i> operator to perform on specified <paramref name="fieldRef"/>.
         /// </summary>
@@ -96,8 +84,8 @@
         /// <returns>IsNull operator instance.</returns>
         public static Operator IsNull<T, TProperty>(Expression<Func<T, TProperty>> fieldRefProperty)
         {
-            return new SimpleOperator(OperatorType.IsNull, GetPropertyFieldNameOrThrow(fieldRefProperty));
-        }
+            return IsNull((FieldReference<T, TProperty>) fieldRefProperty);
+        }   
         
         /// <summary>
         /// Instanciates a new <i>IsNotNull</i> operator to perform on specified <paramref name="fieldRef"/>.
@@ -118,7 +106,7 @@
         /// <returns>IsNotNull operator instance.</returns>
         public static Operator IsNotNull<T, TProperty>(Expression<Func<T, TProperty>> fieldRefProperty)
         {
-            return new SimpleOperator(OperatorType.IsNotNull, GetPropertyFieldNameOrThrow(fieldRefProperty));
+            return IsNotNull((FieldReference<T, TProperty>) fieldRefProperty);
         }
 
         /// <summary>
@@ -145,6 +133,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>Equal</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Equal operator instance.</returns>
+        public static Operator Equal<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return Equal((FieldReference<T, TProperty>) fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Equal</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Equal operator instance.</returns>
+        public static Operator Equal<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return Equal((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>NotEqual</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -154,6 +165,29 @@
         public static Operator NotEqual(FieldReference fieldRef, ValueType valueType, object value)
         {
             return new ComplexOperator(OperatorType.NotEqual, fieldRef, Value.ObjectValue(valueType, value));
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>NotEqual</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>NotEqual operator instance.</returns>
+        public static Operator NotEqual<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return NotEqual((FieldReference<T, TProperty>) fieldRef, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>NotEqual</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>NotEqual operator instance.</returns>
+        public static Operator NotEqual<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return NotEqual((FieldReference<T, TProperty>)fieldRef, valueType, value);
         }
 
         /// <summary>
@@ -191,6 +225,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>BeginsWith</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>BeginsWith operator instance.</returns>
+        public static Operator BeginsWith<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return BeginsWith((FieldReference<T, TProperty>) fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>BeginsWith</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>BeginsWith operator instance.</returns>
+        public static Operator BeginsWith<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return BeginsWith((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>Contains</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -211,6 +268,29 @@
         public static Operator Contains(FieldReference fieldRef, Value value)
         {
             return new ComplexOperator(OperatorType.Contains, fieldRef, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Contains</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Contains operator instance.</returns>
+        public static Operator Contains<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return Contains((FieldReference<T, TProperty>)fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Contains</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Contains operator instance.</returns>
+        public static Operator Contains<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return Contains((FieldReference<T, TProperty>)fieldRef, value);
         }
 
         /// <summary>
@@ -237,6 +317,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>DateRangesOverlap</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>DateRangesOverlap operator instance.</returns>
+        public static Operator DateRangesOverlap<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return DateRangesOverlap((FieldReference<T, TProperty>) fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>DateRangesOverlap</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>DateRangesOverlap operator instance.</returns>
+        public static Operator DateRangesOverlap<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return DateRangesOverlap((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>GreaterThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -257,6 +360,29 @@
         public static Operator GreaterThan(FieldReference fieldRef, Value value)
         {
             return new ComplexOperator(OperatorType.GreaterThan, fieldRef, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>GreaterThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>GreaterThan operator instance.</returns>
+        public static Operator GreaterThan<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return GreaterThan((FieldReference<T, TProperty>) fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>GreaterThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>GreaterThan operator instance.</returns>
+        public static Operator GreaterThan<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return GreaterThan((FieldReference<T, TProperty>)fieldRef, value);
         }
 
         /// <summary>
@@ -283,6 +409,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>GreaterThanOrEqualTo</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>GreaterThanOrEqualTo operator instance.</returns>
+        public static Operator GreaterThanOrEqualTo<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return GreaterThanOrEqualTo((FieldReference<T, TProperty>) fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>GreaterThanOrEqualTo</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>GreaterThanOrEqualTo operator instance.</returns>
+        public static Operator GreaterThanOrEqualTo<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return GreaterThanOrEqualTo((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>LowerThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -303,6 +452,29 @@
         public static Operator LowerThan(FieldReference fieldRef, Value value)
         {
             return new ComplexOperator(OperatorType.LowerThan, fieldRef, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>LowerThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>LowerThan operator instance.</returns>
+        public static Operator LowerThan<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return LowerThan((FieldReference<T, TProperty>)fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>LowerThan</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>LowerThan operator instance.</returns>
+        public static Operator LowerThan<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return LowerThan((FieldReference<T, TProperty>)fieldRef, value);
         }
 
         /// <summary>
@@ -329,6 +501,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>LowerThanOrEqualTo</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>LowerThanOrEqualTo operator instance.</returns>
+        public static Operator LowerThanOrEqualTo<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return LowerThanOrEqualTo((FieldReference<T, TProperty>)fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>LowerThanOrEqualTo</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>LowerThanOrEqualTo operator instance.</returns>
+        public static Operator LowerThanOrEqualTo<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return LowerThanOrEqualTo((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>Includes</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -349,6 +544,29 @@
         public static Operator Includes(FieldReference fieldRef, Value value)
         {
             return new ComplexOperator(OperatorType.Includes, fieldRef, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Includes</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Includes operator instance.</returns>
+        public static Operator Includes<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return Includes((FieldReference<T, TProperty>)fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Includes</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>Includes operator instance.</returns>
+        public static Operator Includes<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return Includes((FieldReference<T, TProperty>)fieldRef, value);
         }
 
         /// <summary>
@@ -375,6 +593,29 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>NotIncludes</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="valueType">Field type</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>NotIncludes operator instance.</returns>
+        public static Operator NotIncludes<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, ValueType valueType, TProperty value)
+        {
+            return NotIncludes((FieldReference<T, TProperty>)fieldRef, valueType, value);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>NotIncludes</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="value">Value against which the value returned by the field element is compared to.</param>
+        /// <returns>NotIncludes operator instance.</returns>
+        public static Operator NotIncludes<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, Value value)
+        {
+            return NotIncludes((FieldReference<T, TProperty>)fieldRef, value);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>In</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -386,6 +627,17 @@
         }
 
         /// <summary>
+        /// Instanciates a new <i>In</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="values">Values against which the value returned by the field element is compared to.</param>
+        /// <returns>In operator instance.</returns>
+        public static Operator In<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, IEnumerable<Value> values)
+        {
+            return In((FieldReference<T, TProperty>)fieldRef, values);
+        }
+
+        /// <summary>
         /// Instanciates a new <i>Membership</i> operator which will perform on specified <paramref name="fieldRef"/>.
         /// </summary>
         /// <param name="fieldRef">Reference to the field to operate on.</param>
@@ -394,6 +646,17 @@
         public static Operator Membership(FieldReference fieldRef, MembershipType membershipType)
         {
             return new MembershipOperator(fieldRef, membershipType);
+        }
+
+        /// <summary>
+        /// Instanciates a new <i>Membership</i> operator which will perform on specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to operate on.</param>
+        /// <param name="membershipType">Type of membership for the operator to use to filter for.</param>
+        /// <returns>Membership operator instance.</returns>
+        public static Operator Membership<T, TProperty>(Expression<Func<T, TProperty>> fieldRef, MembershipType membershipType)
+        {
+            return Membership((FieldReference<T, TProperty>)fieldRef, membershipType);
         }
     }
 }

--- a/src/CamlBuilder/Query.cs
+++ b/src/CamlBuilder/Query.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text;
 using System.Runtime.CompilerServices;
 
@@ -87,6 +89,17 @@ namespace CamlBuilder
         }
 
         /// <summary>
+        /// Adds a new query sort order relatively to a specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field where to perform the ordering on.</param>
+        /// <returns>Returns the query itself.</returns>
+        /// <remarks>Use <see cref="FieldReference.Ascending"/> with false value to specify descending order.</remarks>
+        public Query OrderBy<T, TProperty>(Expression<Func<T, TProperty>> fieldRef)
+        {
+            return OrderBy((FieldReference<T, TProperty>) fieldRef);
+        }
+
+        /// <summary>
         /// Adds a collection of sort orders relatively to specified <paramref name="fieldRefs"/>.
         /// </summary>
         /// <param name="fieldRefs">References to the fields where to perform the ordering on.</param>
@@ -107,6 +120,16 @@ namespace CamlBuilder
         {
             groupByFields.Add(fieldRef);
             return this;
+        }
+
+        /// <summary>
+        /// Specify the query's group-by options. Query will be grouped by specified <paramref name="fieldRef"/>.
+        /// </summary>
+        /// <param name="fieldRef">Reference to the field to group by.</param>
+        /// <returns>Returns the query itself.</returns>
+        public Query GroupBy<T, TProperty>(Expression<Func<T, TProperty>> fieldRef)
+        {
+            return GroupBy((FieldReference<T, TProperty>) fieldRef);
         }
 
         /// <summary>

--- a/src/CamlBuilder/Query.cs
+++ b/src/CamlBuilder/Query.cs
@@ -22,9 +22,9 @@ namespace CamlBuilder
     /// </summary>
     public class Query
     {
-        private readonly List<FieldReference> orderByFields = new List<FieldReference>();
+        private readonly List<FieldReference> _orderByFields = new List<FieldReference>();
 
-        private readonly List<FieldReference> groupByFields = new List<FieldReference>();
+        private readonly List<FieldReference> _groupByFields = new List<FieldReference>();
 
         /// <summary>
         /// Gets the statement holded by this query.
@@ -84,7 +84,7 @@ namespace CamlBuilder
         /// <remarks>Use <see cref="FieldReference.Ascending"/> with false value to specify descending order.</remarks>
         public Query OrderBy(FieldReference fieldRef)
         {
-            orderByFields.Add(fieldRef);
+            _orderByFields.Add(fieldRef);
             return this;
         }
 
@@ -107,7 +107,7 @@ namespace CamlBuilder
         /// <remarks>Use <see cref="FieldReference.Ascending"/> with false value to specify descending order.</remarks>
         public Query OrderBy(IEnumerable<FieldReference> fieldRefs)
         {
-            orderByFields.AddRange(fieldRefs);
+            _orderByFields.AddRange(fieldRefs);
             return this;
         }
 
@@ -118,7 +118,7 @@ namespace CamlBuilder
         /// <returns>Returns the query itself.</returns>
         public Query GroupBy(FieldReference fieldRef)
         {
-            groupByFields.Add(fieldRef);
+            _groupByFields.Add(fieldRef);
             return this;
         }
 
@@ -139,7 +139,7 @@ namespace CamlBuilder
         /// <returns>Returns the query itself.</returns>
         public Query GroupBy(IEnumerable<FieldReference> fieldRefs)
         {
-            groupByFields.AddRange(fieldRefs);
+            _groupByFields.AddRange(fieldRefs);
             return this;
         }
 
@@ -159,13 +159,13 @@ namespace CamlBuilder
 
         private string GetOrderByCaml()
         {
-            if (orderByFields.Count == 0)
+            if (_orderByFields.Count == 0)
             {
                 return string.Empty;
             }
 
             var sb = new StringBuilder();
-            orderByFields.ForEach(o => sb.AppendLine(o.GetCaml()));
+            _orderByFields.ForEach(o => sb.AppendLine(o.GetCaml()));
 
             return $@"
 <OrderBy>
@@ -176,13 +176,13 @@ namespace CamlBuilder
 
         private string GetGroupByCaml()
         {
-            if (groupByFields.Count == 0)
+            if (_groupByFields.Count == 0)
             {
                 return string.Empty;
             }
 
             var sb = new StringBuilder();
-            groupByFields.ForEach(g => sb.AppendLine(g.GetCaml()));
+            _groupByFields.ForEach(g => sb.AppendLine(g.GetCaml()));
 
             return $@"
 <GroupBy>

--- a/tests/CamlBuilder.UnitTests/FieldReferenceTests.cs
+++ b/tests/CamlBuilder.UnitTests/FieldReferenceTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace CamlBuilder.UnitTests
+{
+    public class FieldReferenceTests
+    {
+        private sealed class TestsDto
+        {
+            public string PropName { get; set; }
+
+            public int PropNameInteger { get; set; }
+        }
+
+        [Fact]
+        public void FieldReferenceShouldInferNameFromExpression()
+        {
+            var fieldRef = new FieldReference<TestsDto, string>(t => t.PropName);
+            var fieldRefInteger = new FieldReference<TestsDto, int>(t => t.PropNameInteger);
+
+            Assert.Equal("PropName", fieldRef.Name);
+            Assert.Equal("PropNameInteger", fieldRefInteger.Name);
+        }
+
+        [Fact]
+        public void FieldReferenceCanBeCastedFromExpression()
+        {
+            Expression<Func<TestsDto, string>> expression = t => t.PropName;
+
+            var fieldRef = (FieldReference<TestsDto, string>)expression;
+            
+            Assert.Equal("PropName", fieldRef.Name);
+            Assert.IsAssignableFrom<FieldReference>(fieldRef);
+        }
+    }
+}


### PR DESCRIPTION
Create overloads to be able to initialize operators through strongly-typed methods.

For example, instead of:

`Operator.IsNull("FieldName")`

Do:

`Operator.IsNull<MyClass, PropertyType>(m => m.FieldName)`

This for all Operator factory methods.
